### PR TITLE
feat: Mini.starter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ use {
 - [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
 - [oil.nvim](https://github.com/stevearc/oil.nvim)
 - [dressing.nvim](https://github.com/stevearc/dressing.nvim)
+- [mini.starter](https://github.com/echasnovski/mini.starter)
 
 ## License
 

--- a/lua/shadow/init.lua
+++ b/lua/shadow/init.lua
@@ -280,6 +280,15 @@ local highlights = {
 	OilDir = { fg = colors.blue.gui, ctermfg = colors.blue.cterm }, -- Directory names
 	OilFile = { fg = colors.fg.gui, ctermfg = colors.fg.cterm }, -- File names
 	OilLink = { fg = colors.cyan.gui, ctermfg = colors.cyan.cterm }, -- Symbolic links
+
+	-- mini.starter
+	MiniStarterHeader = { fg = colors.blue.gui, ctermfg = colors.blue.cterm }, -- Header text
+	MiniStarterItem = { fg = colors.fg.gui, ctermfg = colors.fg.cterm }, -- Item text
+	MiniStarterItemBullet = { fg = colors.yellow.gui, ctermfg = colors.yellow.cterm }, -- Bullet points
+	MiniStarterItemPrefix = { fg = colors.green.gui, ctermfg = colors.green.cterm }, -- Prefix text
+	MiniStarterSection = { fg = colors.magenta.gui, ctermfg = colors.magenta.cterm }, -- Section text
+	MiniStarterQuery = { fg = colors.cyan.gui, ctermfg = colors.cyan.cterm }, -- Query text
+	MiniStarterFooter = { fg = colors.red.gui, ctermfg = colors.red.cterm }, -- Footer text
 }
 
 M.colors = colors


### PR DESCRIPTION
Mini.starter

++
PS: Still colorblind 


### no support
<img width="868" alt="Before" src="https://github.com/user-attachments/assets/36031971-c757-45a3-8894-c640869c4a8e" />

### with support
<img width="868" alt="After" src="https://github.com/user-attachments/assets/9a46a335-a26b-4c6b-87a1-38f0d0ab76d2" />
