### PR TITLE
feat: which-key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ use {
 - [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
 - [oil.nvim](https://github.com/stevearc/oil.nvim)
 - [dressing.nvim](https://github.com/stevearc/dressing.nvim)
+- [which-key.nvim](https://github.com/folke/which-key.nvim)
 
 ## License
 

--- a/lua/shadow/init.lua
+++ b/lua/shadow/init.lua
@@ -280,6 +280,14 @@ local highlights = {
 	OilDir = { fg = colors.blue.gui, ctermfg = colors.blue.cterm }, -- Directory names
 	OilFile = { fg = colors.fg.gui, ctermfg = colors.fg.cterm }, -- File names
 	OilLink = { fg = colors.cyan.gui, ctermfg = colors.cyan.cterm }, -- Symbolic links
+
+	-- which-key.nvim
+	WhichKey = { fg = colors.cyan.gui, ctermfg = colors.cyan.cterm },
+	WhichKeySeparator = { fg = colors.black_bright.gui, ctermfg = colors.black_bright.cterm },
+	WhichKeyGroup = { fg = colors.blue.gui, ctermfg = colors.blue.cterm },
+	WhichKeyDesc = { fg = colors.green.gui, ctermfg = colors.green.cterm },
+	WhichKeyFloat = { bg = colors.black.gui, ctermbg = colors.black.cterm },
+	WhichKeyValue = { fg = colors.magenta.gui, ctermfg = colors.magenta.cterm },
 }
 
 M.colors = colors


### PR DESCRIPTION
Original "no support" solution was not that bad honestly, but we can mark a difference between actions and groups.

++

### no support
<img width="1504" alt="Screenshot 2025-02-16 at 20 13 32" src="https://github.com/user-attachments/assets/ff615af0-72e5-4f39-a423-e382c61f8f7a" />

### with support
<img width="1504" alt="Screenshot 2025-02-16 at 20 13 04" src="https://github.com/user-attachments/assets/8373ad4f-f736-4725-9c24-4fbc0a0fa313" />
